### PR TITLE
BashPass version 2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: Shellcheck
+
+on: [push, pull_request]
+
+jobs:
+   build:
+      runs-on: ubuntu-latest
+
+      steps:
+         - uses: actions/checkout@v1
+         - name: Run shellcheck.
+           run: |
+              shopt -s nullglob
+              shellcheck bashpass
+              shellcheck scripts/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
          - name: Run shellcheck.
            run: |
               shopt -s nullglob
-              shellcheck bashpass
-              shellcheck scripts/*
+              shellcheck bashpass -e SC2140
+              shellcheck scripts/* -e SC2016

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ When you decide to open an issue, please use the appropriate template provided.
 -  A quick summary and/or background
 -  Steps to reproduce
    -  Be specific!
-   -  Give sample code if you can. Includes sample code that _anyone_ with a base R setup can run to reproduce what I was seeing
+   -  Give sample code if you can. Includes sample code that _anyone_ with a base Bash knowledge can understand and run. 
 -  What you expected would happen
 -  What actually happens
 -  The version of the software

--- a/README.md
+++ b/README.md
@@ -40,14 +40,12 @@
 
 BashPass is a command-line based password manager written in Bash. It uses GPG to encrypt/decrypt the files where the passwords are stored . This means the passwords are 100% stored locally, so you don't have to trust a third party to store your passwords.
 
-## Features
+## Some Features
 
--  Generating passwords
--  Saving passwords
--  Encrypting/decrypting the password files
--  Copying the password to the clipboard
--  Syncing the passwords with another computer
--  And much more!
+-  Add/edit/delete passwords
+-  Generate passwords
+-  Clipboard support
+-  Safely copy passwords between different devices
 
 ## Documentation
 

--- a/bashpass
+++ b/bashpass
@@ -23,7 +23,7 @@ fi
 # This basically replaces the '$(grep "setting" "$config" | cut -d" " -f2)'.
 # It's also pure bash, which means that no sub shells are used.
 GetSetting() {
-   while read;
+   while read -r;
    do
       if [[ "${REPLY}" =~ ^${1} ]]; then
          printf '%s' "${REPLY#*: }"

--- a/bashpass
+++ b/bashpass
@@ -149,7 +149,7 @@ RandomPassword() {
 
          # Generate a password using '/dev/urandom'.
          # Call the 'tr' command to translate the password to a character set.
-         password=$(LC_ALL=C tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' < /dev/urandom | dd ibs=1 obs=1 count=${length} 2> /dev/null) || :
+         password=$(LC_ALL=C tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' < /dev/urandom | dd ibs=1 obs=1 count="${length}" 2> /dev/null) || :
          ;;
    esac
 

--- a/bashpass
+++ b/bashpass
@@ -252,6 +252,9 @@ Copy() {
    Name "${1}" "copy"
    PasswordExists "${name}"
 
+   # Ignore terminal interrupts (CTRL+C).
+   trap '' INT
+
    # Decrypte the password file and copy it to the clipboard using xclip.
    # This WON'T show the password inside the terminal output.
    if ! printf '%s' "$(gpg --decrypt --quiet "${passLocation}/${name}.gpg")" | xclip -selection clipboard; then

--- a/bashpass
+++ b/bashpass
@@ -49,6 +49,13 @@ Kill() {
    exit "${2}"
 }
 
+# Surprisingly, `sleep` is an external program and not a Bash built-in.
+# So it is possible that it is not installed on a system, although it is very unlikely.
+# We can use `read` to replace the `sleep` command.
+Sleep() {
+   read -rt "${1}" <> <(:) || :
+}
+
 # Return all possible options/usages of BashPass. 
 Help() {
    printf '%s' "\
@@ -257,7 +264,7 @@ Copy() {
    
    # Wait for the timer to end clear the clipboard.
    # 'timer' can be changed in the config file.
-   sleep "${timer}" || kill 0
+   Sleep "${timer}" || kill 0
    xclip -selection clipboard < /dev/null
    
    printf 'Clipboard has been cleared to ensure it cannot be leaked.'

--- a/config/bashpass.conf
+++ b/config/bashpass.conf
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 location: .local/share/bashpass
 timer: 10
 length: 14

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -10,7 +10,7 @@ config="${configLocation}/bashpass.conf"
 # This basically replaces the '$(grep "version" "$config" | cut -d" " -f2)'.
 # It's also pure bash, which means that no sub shells are used.
 GetVersion() {
-   while read;
+   while read -r;
    do
       if [[ "${REPLY}" =~ ^version ]]; then
          printf '%s' "${REPLY#*: }"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -17,7 +17,7 @@ cp "${config}" "${oldConfig}"
 # This basically replaces the '$(grep "setting" "$oldConfig" | cut -d: -f2)'.
 # It's also pure bash, which means that no sub shells are used.
 GetOldSetting() {
-   while read;
+   while read -r;
    do
       if [[ "${REPLY}" =~ ^${1} ]]; then
          printf '%s' "${REPLY#*:}"
@@ -30,7 +30,7 @@ GetOldSetting() {
 # This basically replaces the '$(grep "setting" "$config" | cut -d" " -f2)'.
 # It's also pure bash, which means that no sub shells are used.
 GetNewSetting() {
-   while read;
+   while read -r;
    do
       if [[ "${REPLY}" =~ ^${1} ]]; then
          printf '%s' "${REPLY#*: }"
@@ -43,7 +43,7 @@ GetNewSetting() {
 # This basically replaces the 'sed -i "2s|setting|${newSetting}|g" "${config}"'.
 # It's also pure bash, which means that no sub shells are used.
 ReplaceOldSettings() {
-   while read;
+   while read -r;
    do
       case ${REPLY} in
          "location: "*)
@@ -66,7 +66,7 @@ ReplaceOldSettings() {
 # This basically replaces the 'sed -i "1s|${currentVersion}|${latestVersion}|g" "${config}"'.
 # It's also pure bash, which means that no sub shells are used.
 ReplaceVersion() {
-   while read;
+   while read -r;
    do
       case ${REPLY} in
          "version: "*)

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -100,6 +100,9 @@ Main() {
 
    case $(GetOldSetting 'version') in
       "1.0"| "1.1")
+         # This fixes a bug where the e-mail address was not copied over to the new config format.
+         printf '\n' >> "${oldConfig}"
+
          currentEmail="$(GetOldSetting 'email')" || :
          currentLocation="$(GetOldSetting 'location')" || :
          currentTimer="$(GetOldSetting 'timer')" || :


### PR DESCRIPTION
After discovering a bug in the update script after the release of version [2.0](https://github.com/AntonVanAssche/BashPass/releases/tag/2.0). I decided to start developing for 2.1 right away.

The bug was as follows, when the script tried to upgrade the old configuration to the new format, it didn't copy the email set by BashPass. This was caused by the way the `GetOldSetting` function locates the setting. This function requires an empty line at the end of the configuration file. If you didn't have one, the scripts couldn't read the email address, so it wasn't copied to the new config file with the new format.

This problem was quite easy to fix by just printing a blank line and redirecting it to the old config file. Take a look at commit https://github.com/AntonVanAssche/BashPass/commit/f4e68d08c8d99ff745183212fffddaa4605878ef for more information.